### PR TITLE
[FIX] Status bar position after device rotation

### DIFF
--- a/Source/SideMenuController.swift
+++ b/Source/SideMenuController.swift
@@ -276,7 +276,7 @@ open class SideMenuController: UIViewController, UIGestureRecognizerDelegate {
             return
         }
         
-        sbw?.set(hidden, withBehaviour: _preferences.animating.statusBarBehaviour)
+        sbw?.set(hidden, withBehaviour: _preferences.animating.statusBarBehaviour, isPortrait: UIApplication.shared.statusBarOrientation.isPortrait)
         
         if _preferences.animating.statusBarBehaviour == StatusBarBehaviour.horizontalPan {
             if !hidden {

--- a/Source/UIKitExtensions.swift
+++ b/Source/UIKitExtensions.swift
@@ -75,7 +75,7 @@ public extension UINavigationController {
 }
 
 extension UIWindow {
-    func set(_ hidden: Bool, withBehaviour behaviour: SideMenuController.StatusBarBehaviour) {
+    func set(_ hidden: Bool, withBehaviour behaviour: SideMenuController.StatusBarBehaviour, isPortrait portrait: Bool) {
         let animations: () -> ()
         
         switch behaviour {
@@ -85,7 +85,7 @@ extension UIWindow {
             }
         case .slideAnimation:
             animations = {
-                self.transform = hidden ? CGAffineTransform(translationX: 0, y: -1 * DefaultStatusBarHeight) : CGAffineTransform.identity
+                self.transform = hidden && portrait ? CGAffineTransform(translationX: 0, y: -1 * DefaultStatusBarHeight) : CGAffineTransform.identity
             }
         default:
             return


### PR DESCRIPTION
This is the source of problem about status bar position issue (#687) in Rocket Chat iOS App.