### PR TITLE
fix status bar height on iphone x

### DIFF
--- a/Source/UIKitExtensions.swift
+++ b/Source/UIKitExtensions.swift
@@ -23,7 +23,7 @@
 
 import Foundation
 
-let DefaultStatusBarHeight : CGFloat = 20
+let DefaultStatusBarHeight : CGFloat = UIApplication.shared.statusBarFrame.size.height
 
 extension UIView {
     class func panelAnimation(_ duration : TimeInterval, animations : @escaping (()->()), completion : (()->())? = nil) {


### PR DESCRIPTION
Not the best fix but we can not assume the status bar height is always 20. Might need a bigger refactor, I do not think status bar should matter while laying out views, should just use (save area since iOS 11) constraints.